### PR TITLE
Using heck to convert CamelCase variants to as_snake_case functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ proc-macro = true
 syn = "0.15"
 quote = "0.6"
 proc-macro2 = "0.4"
+heck = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
+use heck::SnakeCase;
 use proc_macro2::{Ident, Span, TokenStream};
 use syn::DeriveInput;
 
@@ -241,7 +242,7 @@ fn impl_all_as_fns(ast: &DeriveInput) -> TokenStream {
     for variant_data in &enum_data.variants {
         let variant_name = &variant_data.ident;
         let function_name = Ident::new(
-            &format!("as_{}", variant_name).to_lowercase(),
+            &format!("as_{}", variant_name).to_snake_case(),
             Span::call_site(),
         );
         let doc = format!(

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate enum_as_inner;
+use enum_as_inner::EnumAsInner;
 
 #[derive(EnumAsInner)]
 enum EmptyTest {}

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -1,16 +1,15 @@
-#[macro_use]
-extern crate enum_as_inner;
+use enum_as_inner::EnumAsInner;
 
 #[derive(EnumAsInner)]
 enum ManyVariants {
-    One{ one: u32 },
-    Two{ one: u32, two: i32 },
-    Three{ one: bool, two: u32, three: i64 },
+    One { one: u32 },
+    Two { one: u32, two: i32 },
+    Three { one: bool, two: u32, three: i64 },
 }
 
 #[test]
 fn test_one_named() {
-    let many = ManyVariants::One{ one: 1 };
+    let many = ManyVariants::One { one: 1 };
 
     assert!(many.as_one().is_some());
     assert!(many.as_two().is_none());
@@ -21,7 +20,7 @@ fn test_one_named() {
 
 #[test]
 fn test_two_named() {
-    let many = ManyVariants::Two{ one: 1, two: 2 };
+    let many = ManyVariants::Two { one: 1, two: 2 };
 
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_some());
@@ -32,7 +31,11 @@ fn test_two_named() {
 
 #[test]
 fn test_three_named() {
-    let many = ManyVariants::Three{ one: true, two: 1, three: 2 };
+    let many = ManyVariants::Three {
+        one: true,
+        two: 1,
+        three: 2,
+    };
 
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_none());

--- a/tests/snake_case.rs
+++ b/tests/snake_case.rs
@@ -1,0 +1,44 @@
+use enum_as_inner::EnumAsInner;
+
+#[derive(EnumAsInner)]
+enum MixedCaseVariants {
+    XMLIsNotCool,
+    #[allow(non_camel_case_types)]
+    Rust_IsCoolThough(u32),
+    YMCA {
+        named: i16,
+    },
+}
+
+#[test]
+fn test_xml_unit() {
+    let mixed = MixedCaseVariants::XMLIsNotCool;
+
+    assert!(mixed.as_xml_is_not_cool().is_some());
+    assert!(mixed.as_rust_is_cool_though().is_none());
+    assert!(mixed.as_ymca().is_none());
+
+    assert_eq!(mixed.as_xml_is_not_cool().unwrap(), ());
+}
+
+#[test]
+fn test_rust_unnamed() {
+    let mixed = MixedCaseVariants::Rust_IsCoolThough(42);
+
+    assert!(mixed.as_xml_is_not_cool().is_none());
+    assert!(mixed.as_rust_is_cool_though().is_some());
+    assert!(mixed.as_ymca().is_none());
+
+    assert_eq!(*mixed.as_rust_is_cool_though().unwrap(), 42);
+}
+
+#[test]
+fn test_ymca_named() {
+    let mixed = MixedCaseVariants::YMCA { named: -32_768 };
+
+    assert!(mixed.as_xml_is_not_cool().is_none());
+    assert!(mixed.as_rust_is_cool_though().is_none());
+    assert!(mixed.as_ymca().is_some());
+
+    assert_eq!(*mixed.as_ymca().unwrap(), (-32_768));
+}

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate enum_as_inner;
+use enum_as_inner::EnumAsInner;
 
 #[derive(EnumAsInner)]
 enum UnitVariants {

--- a/tests/unnamed.rs
+++ b/tests/unnamed.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate enum_as_inner;
+use enum_as_inner::EnumAsInner;
 
 #[derive(EnumAsInner)]
 enum ManyVariants {


### PR DESCRIPTION
Implemented #1 using the [heck](https://crates.io/crates/heck) crate from [withoutboats](https://github.com/withoutboats).

Also ran `cargo fmt` on the sources and updated the tests to rust edition 2018. If you do not like these extra changes, I can revert them of course.