### PR TITLE
Mut ref support + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ enum OneEnum {
 }
 ```
 
-where the inner item can be retrieved with the `as_*()` or with the `into_*()` functions:
+where the inner item can be retrieved with the `as_*()`/`as_*_mut()` or with the `into_*()` functions:
 
 ```rust
 let one = OneEnum::One(1);
 
 assert_eq!(*one.as_one().unwrap(), 1);
+assert_eq!(one.into_one().unwrap(), 1);
+
+let mut one = OneEnum::One(2);
+
+assert_eq!(*one.as_one().unwrap(), 1);
+assert_eq!(*one.as_one_mut().unwrap(), 1);
 assert_eq!(one.into_one().unwrap(), 1);
 ```
 
@@ -69,9 +75,10 @@ enum ManyVariants {
 And can be accessed like:
 
 ```rust
-let many = ManyVariants::Three(true, 1, 2);
+let mut many = ManyVariants::Three(true, 1, 2);
 
 assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
+assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
 assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 ```
 
@@ -93,8 +100,9 @@ enum ManyVariants {
 And can be accessed like:
 
 ```rust
-let many = ManyVariants::Three{ one: true, two: 1, three: 2 };
+let mut many = ManyVariants::Three{ one: true, two: 1, three: 2 };
 
 assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
+assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
 assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,7 @@ fn unnamed_fields_return(
     (function_name_val, doc_val): (&Ident, &str),
     fields: &syn::FieldsUnnamed,
 ) -> TokenStream {
-    let (returns_mut_ref, returns_ref, returns_val, matches) = match fields.unnamed.len()
-    {
+    let (returns_mut_ref, returns_ref, returns_val, matches) = match fields.unnamed.len() {
         1 => {
             let field = fields.unnamed.first().expect("no fields on type");
 
@@ -152,12 +151,7 @@ fn unnamed_fields_return(
             let returns_val = quote!(#returns);
             let matches = quote!(inner);
 
-            (
-                returns_mut_ref,
-                returns_ref,
-                returns_val,
-                matches,
-            )
+            (returns_mut_ref, returns_ref, returns_val, matches)
         }
         0 => (quote!(()), quote!(()), quote!(()), quote!()),
         _ => {
@@ -237,12 +231,7 @@ fn named_fields_return(
             let returns_val = quote!(#returns);
             let matches = quote!(#match_name);
 
-            (
-                returns_mut_ref,
-                returns_ref,
-                returns_val,
-                matches,
-            )
+            (returns_mut_ref, returns_ref, returns_val, matches)
         }
         0 => (quote!(()), quote!(()), quote!(()), quote!(())),
         _ => {
@@ -346,9 +335,13 @@ fn impl_all_as_fns(ast: &DeriveInput) -> TokenStream {
         );
 
         let tokens = match &variant_data.fields {
-            syn::Fields::Unit => {
-                unit_fields_return(name, variant_name, &function_name_mut_ref, &function_name_ref, &doc_ref)
-            }
+            syn::Fields::Unit => unit_fields_return(
+                name,
+                variant_name,
+                &function_name_mut_ref,
+                &function_name_ref,
+                &doc_ref,
+            ),
             syn::Fields::Unnamed(unnamed) => unnamed_fields_return(
                 name,
                 variant_name,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -17,11 +17,15 @@ enum EmptyParendsTest {
 
 #[test]
 fn test_empty_parends() {
-    let empty = EmptyParendsTest::Empty();
+    let mut empty = EmptyParendsTest::Empty();
 
     empty
         .as_empty()
         .expect("should have been something and a unit");
+    empty
+        .as_empty_mut()
+        .expect("should have been something and a unit");
+
     empty
         .into_empty()
         .expect("should have been something and a unit");
@@ -34,9 +38,10 @@ enum OneTest {
 
 #[test]
 fn test_one() {
-    let empty = OneTest::One(1);
+    let mut empty = OneTest::One(1);
 
     assert_eq!(*empty.as_one().unwrap(), 1);
+    assert_eq!(*empty.as_one_mut().unwrap(), 1);
     assert_eq!(empty.into_one().unwrap(), 1);
 }
 
@@ -47,8 +52,9 @@ enum MultiTest {
 
 #[test]
 fn test_multi() {
-    let multi = MultiTest::Multi(1, 1);
+    let mut multi = MultiTest::Multi(1, 1);
 
     assert_eq!(multi.as_multi().unwrap(), (&1_u32, &1_u32));
+    assert_eq!(multi.as_multi_mut().unwrap(), (&mut 1_u32, &mut 1_u32));
     assert_eq!(multi.into_multi().unwrap(), (1_u32, 1_u32));
 }

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -9,30 +9,41 @@ enum ManyVariants {
 
 #[test]
 fn test_one_named() {
-    let many = ManyVariants::One { one: 1 };
+    let mut many = ManyVariants::One { one: 1 };
 
     assert!(many.as_one().is_some());
     assert!(many.as_two().is_none());
     assert!(many.as_three().is_none());
 
+    assert!(many.as_one_mut().is_some());
+    assert!(many.as_two_mut().is_none());
+    assert!(many.as_three_mut().is_none());
+
+
     assert_eq!(*many.as_one().unwrap(), 1_u32);
+    assert_eq!(*many.as_one_mut().unwrap(), 1_u32);
 }
 
 #[test]
 fn test_two_named() {
-    let many = ManyVariants::Two { one: 1, two: 2 };
+    let mut many = ManyVariants::Two { one: 1, two: 2 };
 
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_some());
     assert!(many.as_three().is_none());
+    assert!(many.as_one_mut().is_none());
+    assert!(many.as_two_mut().is_some());
+    assert!(many.as_three_mut().is_none());
+
 
     assert_eq!(many.as_two().unwrap(), (&1_u32, &2_i32));
+    assert_eq!(many.as_two_mut().unwrap(), (&mut 1_u32, &mut 2_i32));
     assert_eq!(many.into_two().unwrap(), (1_u32, 2_i32));
 }
 
 #[test]
 fn test_three_named() {
-    let many = ManyVariants::Three {
+    let mut many = ManyVariants::Three {
         one: true,
         two: 1,
         three: 2,
@@ -41,7 +52,13 @@ fn test_three_named() {
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_none());
     assert!(many.as_three().is_some());
+    assert!(many.as_one_mut().is_none());
+    assert!(many.as_two_mut().is_none());
+    assert!(many.as_three_mut().is_some());
+
 
     assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
+    assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
     assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 }
+

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -19,7 +19,6 @@ fn test_one_named() {
     assert!(many.as_two_mut().is_none());
     assert!(many.as_three_mut().is_none());
 
-
     assert_eq!(*many.as_one().unwrap(), 1_u32);
     assert_eq!(*many.as_one_mut().unwrap(), 1_u32);
 }
@@ -34,7 +33,6 @@ fn test_two_named() {
     assert!(many.as_one_mut().is_none());
     assert!(many.as_two_mut().is_some());
     assert!(many.as_three_mut().is_none());
-
 
     assert_eq!(many.as_two().unwrap(), (&1_u32, &2_i32));
     assert_eq!(many.as_two_mut().unwrap(), (&mut 1_u32, &mut 2_i32));
@@ -56,9 +54,10 @@ fn test_three_named() {
     assert!(many.as_two_mut().is_none());
     assert!(many.as_three_mut().is_some());
 
-
     assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
-    assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
+    assert_eq!(
+        many.as_three_mut().unwrap(),
+        (&mut true, &mut 1_u32, &mut 2_i64)
+    );
     assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 }
-

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -9,33 +9,45 @@ enum UnitVariants {
 
 #[test]
 fn test_zero_unit() {
-    let unit = UnitVariants::Zero;
+    let mut unit = UnitVariants::Zero;
 
     assert!(unit.as_zero().is_some());
     assert!(unit.as_one().is_none());
     assert!(unit.as_two().is_none());
+
+    assert!(unit.as_zero_mut().is_some());
+    assert!(unit.as_one_mut().is_none());
+    assert!(unit.as_two_mut().is_none());
 
     unit.as_zero().expect("expected ");
 }
 
 #[test]
 fn test_one_unit() {
-    let unit = UnitVariants::One;
+    let mut unit = UnitVariants::One;
 
     assert!(unit.as_zero().is_none());
     assert!(unit.as_one().is_some());
     assert!(unit.as_two().is_none());
+
+    assert!(unit.as_zero_mut().is_none());
+    assert!(unit.as_one_mut().is_some());
+    assert!(unit.as_two_mut().is_none());
 
     unit.as_one().expect("should have been some unit");
 }
 
 #[test]
 fn test_two_unit() {
-    let unit = UnitVariants::Two;
+    let mut unit = UnitVariants::Two;
 
     assert!(unit.as_zero().is_none());
     assert!(unit.as_one().is_none());
     assert!(unit.as_two().is_some());
+
+    assert!(unit.as_zero_mut().is_none());
+    assert!(unit.as_one_mut().is_none());
+    assert!(unit.as_two_mut().is_some());
 
     unit.as_two().expect("should have been some unit");
 }

--- a/tests/unnamed.rs
+++ b/tests/unnamed.rs
@@ -19,7 +19,6 @@ fn test_one_unnamed() {
     assert!(many.as_two_mut().is_none());
     assert!(many.as_three_mut().is_none());
 
-
     assert_eq!(*many.as_one().unwrap(), 1_u32);
     assert_eq!(*many.as_one_mut().unwrap(), 1_u32);
     assert_eq!(many.into_one().unwrap(), 1_u32);
@@ -55,6 +54,9 @@ fn test_three_unnamed() {
     assert!(many.as_three_mut().is_some());
 
     assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
-    assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
+    assert_eq!(
+        many.as_three_mut().unwrap(),
+        (&mut true, &mut 1_u32, &mut 2_i64)
+    );
     assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 }

--- a/tests/unnamed.rs
+++ b/tests/unnamed.rs
@@ -9,36 +9,52 @@ enum ManyVariants {
 
 #[test]
 fn test_one_unnamed() {
-    let many = ManyVariants::One(1);
+    let mut many = ManyVariants::One(1);
 
     assert!(many.as_one().is_some());
     assert!(many.as_two().is_none());
     assert!(many.as_three().is_none());
 
+    assert!(many.as_one_mut().is_some());
+    assert!(many.as_two_mut().is_none());
+    assert!(many.as_three_mut().is_none());
+
+
     assert_eq!(*many.as_one().unwrap(), 1_u32);
+    assert_eq!(*many.as_one_mut().unwrap(), 1_u32);
     assert_eq!(many.into_one().unwrap(), 1_u32);
 }
 
 #[test]
 fn test_two_unnamed() {
-    let many = ManyVariants::Two(1, 2);
+    let mut many = ManyVariants::Two(1, 2);
 
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_some());
     assert!(many.as_three().is_none());
 
+    assert!(many.as_one_mut().is_none());
+    assert!(many.as_two_mut().is_some());
+    assert!(many.as_three_mut().is_none());
+
     assert_eq!(many.as_two().unwrap(), (&1_u32, &2_i32));
+    assert_eq!(many.as_two_mut().unwrap(), (&mut 1_u32, &mut 2_i32));
     assert_eq!(many.into_two().unwrap(), (1_u32, 2_i32));
 }
 
 #[test]
 fn test_three_unnamed() {
-    let many = ManyVariants::Three(true, 1, 2);
+    let mut many = ManyVariants::Three(true, 1, 2);
 
     assert!(many.as_one().is_none());
     assert!(many.as_two().is_none());
     assert!(many.as_three().is_some());
 
+    assert!(many.as_one_mut().is_none());
+    assert!(many.as_two_mut().is_none());
+    assert!(many.as_three_mut().is_some());
+
     assert_eq!(many.as_three().unwrap(), (&true, &1_u32, &2_i64));
+    assert_eq!(many.as_three_mut().unwrap(), (&mut true, &mut 1_u32, &mut 2_i64));
     assert_eq!(many.into_three().unwrap(), (true, 1_u32, 2_i64));
 }


### PR DESCRIPTION
- add mut ref support
- previously, we've generated code which returned references to references, this is now fixed
- simplify code by not using additional vars for `accesses_*`, since they're now basically `matches` in parens

p.s. would be awesome to publish a new version if this is merged 🙂