### PR TITLE
Change unit variants to use predicate functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ where the result is either a reference for inner items or a tuple containing the
 
 ## Unit case
 
-This will return copy's of the value of the unit variant, as `isize`:
+This will return true if enum's variant matches the expected type
 
 ```rust
 use enum_as_inner::EnumAsInner;
@@ -45,17 +45,11 @@ enum UnitVariants {
     One,
     Two,
 }
-```
 
-These are not references:
-
-```rust
 let unit = UnitVariants::Two;
 
-assert_eq!(unit.as_two().unwrap(), ());
+assert!(unit.is_two());
 ```
-
-Note that for unit enums there is no `into_*()` function generated.
 
 ## Mutliple, unnamed field case
 

--- a/tests/snake_case.rs
+++ b/tests/snake_case.rs
@@ -1,6 +1,7 @@
 use enum_as_inner::EnumAsInner;
 
 #[derive(Debug, EnumAsInner)]
+#[allow(clippy::upper_case_acronyms)]
 enum MixedCaseVariants {
     XMLIsNotCool,
     #[allow(non_camel_case_types)]
@@ -14,20 +15,16 @@ enum MixedCaseVariants {
 fn test_xml_unit() {
     let mixed = MixedCaseVariants::XMLIsNotCool;
 
-    assert!(mixed.as_xml_is_not_cool().is_some());
+    assert!(mixed.is_xml_is_not_cool());
     assert!(mixed.as_rust_is_cool_though().is_none());
     assert!(mixed.as_ymca().is_none());
-
-    mixed
-        .as_xml_is_not_cool()
-        .expect("should have been some unit");
 }
 
 #[test]
 fn test_rust_unnamed() {
     let mixed = MixedCaseVariants::Rust_IsCoolThough(42);
 
-    assert!(mixed.as_xml_is_not_cool().is_none());
+    assert!(!mixed.is_xml_is_not_cool());
     assert!(mixed.as_rust_is_cool_though().is_some());
     assert!(mixed.as_ymca().is_none());
 
@@ -39,7 +36,7 @@ fn test_rust_unnamed() {
 fn test_ymca_named() {
     let mixed = MixedCaseVariants::YMCA { named: -32_768 };
 
-    assert!(mixed.as_xml_is_not_cool().is_none());
+    assert!(!mixed.is_xml_is_not_cool());
     assert!(mixed.as_rust_is_cool_though().is_none());
     assert!(mixed.as_ymca().is_some());
 

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -9,45 +9,28 @@ enum UnitVariants {
 
 #[test]
 fn test_zero_unit() {
-    let mut unit = UnitVariants::Zero;
+    let unit = UnitVariants::Zero;
 
-    assert!(unit.as_zero().is_some());
-    assert!(unit.as_one().is_none());
-    assert!(unit.as_two().is_none());
-
-    assert!(unit.as_zero_mut().is_some());
-    assert!(unit.as_one_mut().is_none());
-    assert!(unit.as_two_mut().is_none());
-
-    unit.as_zero().expect("expected ");
+    assert!(unit.is_zero());
+    assert!(!unit.is_one());
+    assert!(!unit.is_two());
 }
 
 #[test]
 fn test_one_unit() {
-    let mut unit = UnitVariants::One;
+    let unit = UnitVariants::One;
 
-    assert!(unit.as_zero().is_none());
-    assert!(unit.as_one().is_some());
-    assert!(unit.as_two().is_none());
+    assert!(!unit.is_zero());
+    assert!(unit.is_one());
+    assert!(!unit.is_two());
 
-    assert!(unit.as_zero_mut().is_none());
-    assert!(unit.as_one_mut().is_some());
-    assert!(unit.as_two_mut().is_none());
-
-    unit.as_one().expect("should have been some unit");
 }
 
 #[test]
 fn test_two_unit() {
-    let mut unit = UnitVariants::Two;
+    let unit = UnitVariants::Two;
 
-    assert!(unit.as_zero().is_none());
-    assert!(unit.as_one().is_none());
-    assert!(unit.as_two().is_some());
-
-    assert!(unit.as_zero_mut().is_none());
-    assert!(unit.as_one_mut().is_none());
-    assert!(unit.as_two_mut().is_some());
-
-    unit.as_two().expect("should have been some unit");
+    assert!(!unit.is_zero());
+    assert!(!unit.is_one());
+    assert!(unit.is_two());
 }


### PR DESCRIPTION
Currently, unit variants return an option of the unit type. This does not offer any more information or functionality then a predicate function. The `is_*` functions are nicer to use and lead to simpler code.