### PR TITLE
Fully qualify both Option and Result in generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,23 +176,23 @@ fn unnamed_fields_return(
 
         #[doc = #doc_mut_ref ]
         #[inline]
-        pub fn #function_name_mut_ref(&mut self) -> Option<#returns_mut_ref> {
+        pub fn #function_name_mut_ref(&mut self) -> ::core::option::Option<#returns_mut_ref> {
             match self {
                 Self::#variant_name(#matches) => {
-                    Some((#matches))
+                    ::core::option::Option::Some((#matches))
                 }
-                _ => None
+                _ => ::core::option::Option::None
             }
         }
 
         #[doc = #doc_ref ]
         #[inline]
-        pub fn #function_name_ref(&self) -> Option<#returns_ref> {
+        pub fn #function_name_ref(&self) -> ::core::option::Option<#returns_ref> {
             match self {
                 Self::#variant_name(#matches) => {
-                    Some((#matches))
+                    ::core::option::Option::Some((#matches))
                 }
-                _ => None
+                _ => ::core::option::Option::None
             }
         }
 
@@ -201,9 +201,9 @@ fn unnamed_fields_return(
         pub fn #function_name_val(self) -> ::core::result::Result<#returns_val, Self> {
             match self {
                 Self::#variant_name(#matches) => {
-                    Ok((#matches))
+                    ::core::result::Result::Ok((#matches))
                 },
-                _ => Err(self)
+                _ => ::core::result::Result::Err(self)
             }
         }
     )
@@ -267,23 +267,23 @@ fn named_fields_return(
 
         #[doc = #doc_mut_ref ]
         #[inline]
-        pub fn #function_name_mut_ref(&mut self) -> Option<#returns_mut_ref> {
+        pub fn #function_name_mut_ref(&mut self) -> ::core::option::Option<#returns_mut_ref> {
             match self {
                 Self::#variant_name{ #matches } => {
-                    Some((#matches))
+                    ::core::option::Option::Some((#matches))
                 }
-                _ => None
+                _ => ::core::option::Option::None
             }
         }
 
         #[doc = #doc_ref ]
         #[inline]
-        pub fn #function_name_ref(&self) -> Option<#returns_ref> {
+        pub fn #function_name_ref(&self) -> ::core::option::Option<#returns_ref> {
             match self {
                 Self::#variant_name{ #matches } => {
-                    Some((#matches))
+                    ::core::option::Option::Some((#matches))
                 }
-                _ => None
+                _ => ::core::option::Option::None
             }
         }
 
@@ -292,9 +292,9 @@ fn named_fields_return(
         pub fn #function_name_val(self) -> ::core::result::Result<#returns_val, Self> {
             match self {
                 Self::#variant_name{ #matches } => {
-                    Ok((#matches))
+                    ::core::result::Result::Ok((#matches))
                 }
-                _ => Err(self)
+                _ => ::core::result::Result::Err(self)
             }
         }
     )

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,8 +16,8 @@ use enum_as_inner::EnumAsInner;
 
 pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    pub struct Some;
     pub struct Option;
+    pub struct Some;
     pub struct None;
     pub struct Result;
     pub struct Ok;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Some;
+    pub struct Option;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -14,12 +14,24 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[derive(Debug, EnumAsInner)]
 enum EmptyTest {}
 
 #[test]
 fn test_empty() {
-    let empty = None::<EmptyTest>;
+    let empty = std::option::Option::None::<EmptyTest>;
 
     assert!(empty.is_none());
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -14,6 +14,18 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, EnumAsInner)]
 enum WithGenerics<T: Clone + Copy> {

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/named.rs
+++ b/tests/named.rs
@@ -14,6 +14,18 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[derive(Debug, EnumAsInner)]
 enum ManyVariants {
     One { one: u32 },

--- a/tests/snake_case.rs
+++ b/tests/snake_case.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/snake_case.rs
+++ b/tests/snake_case.rs
@@ -14,6 +14,18 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[derive(Debug, EnumAsInner)]
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -14,6 +14,18 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[derive(EnumAsInner)]
 enum UnitVariants {
     Zero,

--- a/tests/unnamed.rs
+++ b/tests/unnamed.rs
@@ -14,14 +14,14 @@
 
 use enum_as_inner::EnumAsInner;
 
-mod name_collisions {
+pub mod name_collisions {
     #![allow(dead_code, missing_copy_implementations, missing_docs)]
-    struct Option;
-    struct Some;
-    struct None;
-    struct Result;
-    struct Ok;
-    struct Err;
+    pub struct Option;
+    pub struct Some;
+    pub struct None;
+    pub struct Result;
+    pub struct Ok;
+    pub struct Err;
 }
 #[allow(unused_imports)]
 use name_collisions::*;

--- a/tests/unnamed.rs
+++ b/tests/unnamed.rs
@@ -14,6 +14,18 @@
 
 use enum_as_inner::EnumAsInner;
 
+mod name_collisions {
+    #![allow(dead_code, missing_copy_implementations, missing_docs)]
+    struct Option;
+    struct Some;
+    struct None;
+    struct Result;
+    struct Ok;
+    struct Err;
+}
+#[allow(unused_imports)]
+use name_collisions::*;
+
 #[derive(Debug, EnumAsInner)]
 enum ManyVariants {
     One(u32),


### PR DESCRIPTION
... along with their variants. This allows the generated code to still work alongside conflicting names like `None` in scope.

This was already done for `::core::result::Result`, but this diff extends the same treatment to `::core::result::Result::Ok`, `::core::result::Result::Err`, `::core::option::Option`, `::core::option::Option::Some`, and `::core::option::Option::None`.